### PR TITLE
build: change build config for Node.js 16

### DIFF
--- a/__tests__/send-comment.test.ts
+++ b/__tests__/send-comment.test.ts
@@ -1,5 +1,4 @@
 import { getOctokit } from '@actions/github'
-import { mocked } from 'ts-jest/utils'
 
 import { sendCommentAsync } from '../src/send-comment'
 import { generateRandomString } from './util'
@@ -28,11 +27,12 @@ describe('send-comment.ts', () => {
       await sendCommentAsync(token, owner, repo, issueNumber, comment)
 
       // Assert
-      const mockedInstance = jest.mocked(getOctokit).mock.results[0].value
-      expect(mocked(getOctokit)).toHaveBeenCalledTimes(1)
-      expect(mocked(getOctokit)).toHaveBeenCalledWith(token)
-      expect(mockedInstance.rest.issues.createComment).toHaveBeenCalledTimes(1)
-      expect(mockedInstance.rest.issues.createComment).toHaveBeenCalledWith({
+      expect(jest.mocked(getOctokit)).toHaveBeenCalledTimes(1)
+      expect(jest.mocked(getOctokit)).toHaveBeenCalledWith(token)
+      const octokit: ReturnType<typeof getOctokit> =
+        jest.mocked(getOctokit).mock.results[0]?.value
+      expect(octokit.rest.issues.createComment).toHaveBeenCalledTimes(1)
+      expect(octokit.rest.issues.createComment).toHaveBeenCalledWith({
         owner,
         repo,
         issue_number: issueNumber,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@octokit/webhooks-types": "^5.4.0",
     "@tsconfig/node12": "^1.0.9",
+    "@tsconfig/node16-strictest": "^1.0.0",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": ">=12",
+    "node": ">=16",
     "yarn": "^1.22.4"
   },
   "scripts": {
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@octokit/webhooks-types": "^5.4.0",
-    "@tsconfig/node12": "^1.0.9",
     "@tsconfig/node16-strictest": "^1.0.0",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node16-strictest/tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,7 +697,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
   integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
 
-"@tsconfig/node12@^1.0.7", "@tsconfig/node12@^1.0.9":
+"@tsconfig/node12@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
   integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
   integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
+"@tsconfig/node16-strictest@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16-strictest/-/node16-strictest-1.0.0.tgz#ce2ac0bc61b206acd7dbba28c7fe78cd0dac2f5f"
+  integrity sha512-MTrFOCoWfjjhFpAoeHmWXFnYeRPxMBMgaNVszBYXJgPFi7XHYdRrDatgyk+Nb0ht7jWP3j/J3xXfvSXIjzRVKA==
+
 "@tsconfig/node16@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"


### PR DESCRIPTION
- use `@tsconfig/node16-strictest` instead of `@tsconfig/node12`
- bump `engines.node` verison to `>=16` in `package.json`