### PR TITLE
test(integration): add & remove runner

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -78,8 +78,9 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
+          - macos-14
+          - macos-13
           - macos-12
-          - macos-11
           - windows-2022
           - windows-2019
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Add `macos-14`, `macos-13` runner
- Remove `macos-11` runner (deprecated after 2024-06-28)